### PR TITLE
Support air-gap with helm repos

### DIFF
--- a/entry
+++ b/entry
@@ -10,7 +10,8 @@ update-ca-certificates
 tiller --listen=127.0.0.1:44134 --storage=secret &
 export HELM_HOST=127.0.0.1:44134
 
-helm init --client-only
+helm init --skip-refresh --client-only
+helm repo update --strict || helm repo remove stable
 if [ -n "$REPO" ]; then
     helm repo add ${NAME%%/*} $REPO
 fi


### PR DESCRIPTION
If default stable helm repo is not available then helm init or installs
will also fail. Test if updating default repos fail and if so remove
stable repo so install from other sources will succeed.