### PR TITLE
Fix typo

### DIFF
--- a/entry
+++ b/entry
@@ -40,7 +40,7 @@ helm_update() {
   fi
 
   if [ "$STATUS" = "failed" ] || [ "$STATUS" = "deleted" ]; then
-    if [ "$HELM" == "helm_v3"]; then
+    if [ "$HELM" == "helm_v3" ]; then
         $HELM uninstall $NAME
     else
         $HELM "$@" --purge $NAME


### PR DESCRIPTION
Closes https://github.com/rancher/klipper-helm/issues/10

reproduce issue with this example:
```
export HELM=helm_v3
if [ "$HELM" == "helm_v3"]; then
    echo "intended"
else
    echo "accident"
fi
```

Found while playing with k3s.

I found the pod was crash looping, so I deleted it to find the relevant logs. By describing the pod I found this repository from the pod's docker image.
```
steven@xxxxxx:~/my_apps/tiller$ kubectl get pods -n kube-system                                                                                            
NAME                                      READY   STATUS              RESTARTS   AGE                                                                         
metrics-server-6d684c7b5-m5rj5            1/1     Running             0          14m                                                                         
local-path-provisioner-58fb86bdfd-lxhbw   1/1     Running             0          14m                                                                         
coredns-d798c9dd-9pbjh                    1/1     Running             0          14m                                                                         
svclb-traefik-f2vr2                       2/2     Running             0          13m                                                                         
svclb-traefik-d6kv9                       2/2     Running             0          13m                                                                         
svclb-traefik-f5hsl                       2/2     Running             0          13m                                                                         
svclb-traefik-cgtq8                       2/2     Running             0          11m                                                                         
svclb-traefik-9tqt9                       2/2     Running             0          13m                                                                         
helm-install-traefik-k8prt                0/1     Terminating         7          14m                                                                         
helm-install-traefik-vb4hh                0/1     ContainerCreating   0          3s                
```

The following log informed of this typo
```                                                          
steven@xxxxxx:~/my_apps/tiller$ kubectl logs -n kube-system -f helm-install-traefik-vb4hh                                                                  
CHART=$(sed -e "s/%{KUBERNETES_API}%/${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/g" <<< "${CHART}")                                                
set +v -x                                                                                                                                                    
+ cp /var/run/secrets/kubernetes.io/serviceaccount/ca.crt /usr/local/share/ca-certificates/                                                                  
+ update-ca-certificates                                                                                                                                     
WARNING: ca-certificates.crt does not contain exactly one certificate or CRL: skipping                                                                       
+ export HELM_HOST=127.0.0.1:44134                                                                                                                           
+ tiller --listen=127.0.0.1:44134 + --storage=secret                                                                                                         
HELM_HOST=127.0.0.1:44134                                                                                                                                    
+ helm_v2 init --skip-refresh --client-only                                                                                                                  
[main] 2020/01/02 04:12:26 Starting Tiller v2.12.3 (tls=false)                                                                                               
[main] 2020/01/02 04:12:26 GRPC listening on 127.0.0.1:44134                                                                                                 
... omitted ...
+ helm_update install --set-string kubernetes.ingressEndpoint.useDefaultPublishedService=true --set-string metrics.prometheus.enabled=true --set-string rbac.
enabled=true --set-string ssl.enabled=true
+ '[' helm_v3 == helm_v3 ']'
++ helm_v3 ls --all -f '^traefik$' --output json
++ jq -r '"\(.[0].app_version),\(.[0].status)"'
++ tr '[:upper:]' '[:lower:]'
+ LINE=1.7.19,failed
++ echo 1.7.19,failed
++ cut -f1 -d,
+ INSTALLED_VERSION=1.7.19
++ echo 1.7.19,failed
++ cut -f2 -d,
+ STATUS=failed
+ '[' -e /config/values.yaml ']'
+ '[' install = delete ']'
+ '[' -z 1.7.19 ']'
+ '[' -z '' ']'
+ '[' failed = deployed ']'
+ '[' failed = failed ']'
+ '[' helm_v3 == 'helm_v3]'
/usr/bin/entry: line 43: [: missing `]'
```