### PR TITLE
Updated entry to correct logic for upgrade of helm charts

### DIFF
--- a/entry
+++ b/entry
@@ -30,7 +30,7 @@ helm_update() {
       $HELM "$@" $NAME_ARG $NAME $CHART $VALUES
       exit
   fi
-  if [ -z "$VERSION" ] || [ "$INSTALLED_VERSION" = "$VERSION" ]; then
+  if [ -z "$VERSION" ] || [ "$INSTALLED_VERSION" != "$VERSION" ]; then
       if [ "$STATUS" = "deployed" ]; then
           echo Already installed $NAME, upgrading
           shift 1


### PR DESCRIPTION
Currently upgrading helm charts using the helm-controller fails due to check in the `entry` script for INSTALLED_VERSION and VERSIONS.

As a result the code block is never executed and the default `helm install... ` block is executed on line 53:

https://github.com/rancher/klipper-helm/blob/master/entry#L53

By tweaking the comparison logic, we can correctly handle the chart upgrades. 

Related to issue: [helm controller issue](https://github.com/rancher/helm-controller/issues/32)