### PR TITLE
Upgrade Helm v2 and v3 binaries

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.8 as extract
 RUN apk add -U curl ca-certificates
 ARG ARCH
-RUN curl https://storage.googleapis.com/kubernetes-helm/helm-v2.12.3-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
+RUN curl https://storage.googleapis.com/kubernetes-helm/helm-v2.16.7-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
 RUN mv /usr/bin/helm /usr/bin/helm_v2
 RUN curl https://get.helm.sh/helm-v3.0.0-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
 RUN mv /usr/bin/helm /usr/bin/helm_v3

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -3,7 +3,7 @@ RUN apk add -U curl ca-certificates
 ARG ARCH
 RUN curl https://storage.googleapis.com/kubernetes-helm/helm-v2.16.7-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
 RUN mv /usr/bin/helm /usr/bin/helm_v2
-RUN curl https://get.helm.sh/helm-v3.0.0-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
+RUN curl https://get.helm.sh/helm-v3.2.1-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
 RUN mv /usr/bin/helm /usr/bin/helm_v3
 
 FROM alpine:3.8


### PR DESCRIPTION
This PR is upgrading the version of the Helm binaries included in the current `rancher/klipper-helm:v0.2.5` image respectively to v2.16.7 and v3.2.1.