### PR TITLE
Ignore repo update for chart delete

### DIFF
--- a/entry
+++ b/entry
@@ -111,6 +111,8 @@ if [ "$EXIST" == "1" ] || [ "$HELM_VERSION" == "v2" ]; then
 fi
 
 helm_content_decode
-helm_repo_init
+if [ "$1" != "delete" ]; then
+  helm_repo_init
+fi
 helm_update $@
 


### PR DESCRIPTION
- For an installed chart, deletion can happen over with name and do not require the repo update.
- This will come handy where for some reason repo update fails while deleting the installed chart.
- fixes https://github.com/rancher/helm-controller/issues/55